### PR TITLE
Search Zendesk organizations using organization name

### DIFF
--- a/zendesk/org.go
+++ b/zendesk/org.go
@@ -2,6 +2,7 @@ package zendesk
 
 import (
 	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/google/go-querystring/query"
@@ -74,4 +75,11 @@ func (c *client) ListOrganizations(opts *ListOptions) ([]Organization, error) {
 // Zendesk Core API docs: https://developer.zendesk.com/rest_api/docs/core/organizations#delete-organization
 func (c *client) DeleteOrganization(id int64) error {
 	return c.delete(fmt.Sprintf("/api/v2/organizations/%d.json", id), nil)
+}
+
+func (c *client) AutocompleteOrganizations(name string) ([]Organization, error) {
+	out := new(APIPayload)
+	name = url.QueryEscape(name)
+	err := c.get("/api/v2/organizations/autocomplete.json?name="+name, out)
+	return out.Organizations, err
 }

--- a/zendesk/zendesk.go
+++ b/zendesk/zendesk.go
@@ -20,6 +20,7 @@ type Client interface {
 	WithHeader(name, value string) Client
 
 	AddUserTags(int64, []string) ([]string, error)
+	AutocompleteOrganizations(string) ([]Organization, error)
 	BatchUpdateManyTickets([]Ticket) error
 	BulkUpdateManyTickets([]int64, *Ticket) error
 	CreateIdentity(int64, *UserIdentity) (*UserIdentity, error)

--- a/zendesk/zendesk_test.go
+++ b/zendesk/zendesk_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/EverlongProject/go-zendesk/zendesk"
+	"github.com/MEDIGO/go-zendesk/zendesk"
 	"github.com/stretchr/testify/require"
 )
 

--- a/zendesk/zendesk_test.go
+++ b/zendesk/zendesk_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/MEDIGO/go-zendesk/zendesk"
+	"github.com/EverlongProject/go-zendesk/zendesk"
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
We want the ability to search Zendesk Organizations by organization name. There are multiple ways to do this, but the easiest is via the [Autocomplete Organizations API](https://developer.zendesk.com/rest_api/docs/core/organizations#autocomplete-organizations).

### Added
- a new method called `AutocompleteOrganizations` for searching Zendesk organizations using a company name

### Updated
- `Client` interface to include the new `AutocompleteOrganizations` method